### PR TITLE
Backport to C++11

### DIFF
--- a/type_info_extractor-beta/pod_extractor/mimic_type.h
+++ b/type_info_extractor-beta/pod_extractor/mimic_type.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#if defined(CPP_14) || defined(TRY_CPP_14_TESTS)
 #include "pod_inspector.h"
 #include "build_type.h"
 
+#ifdef CPP_14
 template<typename...Ti>
 constexpr auto form_type()
 {
@@ -23,6 +23,35 @@ constexpr auto mimic_type()
     return mimic_type<Type,Count>(std::make_index_sequence<info.index>{});
 }
 #else
-#warning mimic_type works strictly only using c++14
+template<typename...Ti, typename RetT = typename build_type<Ti...>::result>
+constexpr auto form_type() -> decltype (RetT{})
+{
+    return {};
+}
+
+template<typename Type, size_t Count = fields_count<Type>(), size_t... I>
+constexpr auto mimic_type()
+    -> decltype (form_type<
+                     typename get_type<
+                           get_pod_meta_infos<Type, Count,true>().type_ids[I]
+                        >::type...
+                >())
+{
+    return form_type<
+                typename get_type<
+                    get_pod_meta_infos<Type, Count,true>().type_ids[I]
+                >::type...
+            >();
+}
+template<typename Type, size_t Count = fields_count<Type>()>
+constexpr auto mimic_type()
+    -> decltype (mimic_type<Type,Count>(std::make_index_sequence<
+                                            get_pod_meta_infos<Type, Count, true>().index
+                                        >{}))
+{
+    return mimic_type<Type,Count>(std::make_index_sequence<
+                                    get_pod_meta_infos<Type, Count, true>().index
+                                  >{});
+}
 #endif // CPP_14
 

--- a/type_info_extractor-beta/pod_extractor/typeid_array.h
+++ b/type_info_extractor-beta/pod_extractor/typeid_array.h
@@ -42,7 +42,13 @@ struct typeid_array
             type_meta_info[index] = info,
 #else
 #endif
+#ifdef CPP_11
+            const_cast<typeid_array*>(this)->
+#endif
             type_ids[index] = info.type_index,
+#ifdef CPP_11
+            const_cast<typeid_array*>(this)->
+#endif
             index = index + 1;
 	}
     constexpr std::size_t addInfo(const std::size_t type_id) const


### PR DESCRIPTION
Да, убирать правый const это ужасно. С другой стороны, с 11-м стандартом возможности реализовать неконстантый нестатический constexpr-метод не существует.
Кстати,
```constexpr std::size_t addInfo(const std::size_t type_id) const```
никогда не соберётся, т.к. правый const + модификация полей класса.